### PR TITLE
Fix bug in NiFi flow file creation

### DIFF
--- a/create-nifi-flowfile.py
+++ b/create-nifi-flowfile.py
@@ -14,7 +14,7 @@ def createflowfile ( attributes, content ):
 
   attrarray = bytearray()
 
-  for key, val in attrs.items():
+  for key, val in attributes.items():
     if len(key) <= 65535:
       attrarray.extend((len(key)).to_bytes(2, byteorder='big'))
     else:


### PR DESCRIPTION
## Summary
- fix variable reference in `create-nifi-flowfile.py`

## Testing
- `python3 -m py_compile create-nifi-flowfile.py`

------
https://chatgpt.com/codex/tasks/task_e_684069a7c89c8321b2a8b11c9f6ea0ac